### PR TITLE
feat: create default collection for free concepts

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/adapter/OrganizationsAdapter.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/adapter/OrganizationsAdapter.kt
@@ -1,0 +1,42 @@
+package no.fdk.fdk_concept_harvester.adapter
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.fdk.fdk_concept_harvester.configuration.ApplicationProperties
+import no.fdk.fdk_concept_harvester.model.Organization
+import org.slf4j.LoggerFactory
+import org.springframework.http.*
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+private val logger = LoggerFactory.getLogger(HarvestAdminAdapter::class.java)
+
+@Service
+class OrganizationsAdapter(private val applicationProperties: ApplicationProperties) {
+
+    fun getOrganization(id: String): Organization? {
+        val uri = "${applicationProperties.organizationsUri}/$id"
+        with(URL(uri).openConnection() as HttpURLConnection) {
+            try {
+                setRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString())
+
+                if (HttpStatus.valueOf(responseCode).is2xxSuccessful) {
+                    val body = inputStream.bufferedReader().use(BufferedReader::readText)
+                    return jacksonObjectMapper()
+                        .readValue<Organization?>(body)
+                        ?.copy(uri = uri)
+                } else {
+                    logger.error("Fetch of organization with id $id failed, status: $responseCode")
+                }
+            } catch (ex: Exception) {
+                logger.error("Error fetching organization with id $id", ex)
+            } finally {
+                disconnect()
+            }
+            return null
+        }
+    }
+
+}

--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/configuration/ApplicationProperties.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/configuration/ApplicationProperties.kt
@@ -8,5 +8,6 @@ import org.springframework.boot.context.properties.ConstructorBinding
 data class ApplicationProperties(
     val conceptsUri: String,
     val collectionsUri: String,
+    val organizationsUri: String,
     val harvestAdminRootUrl: String
 )

--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/model/HarvestDataSource.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/model/HarvestDataSource.kt
@@ -7,5 +7,6 @@ data class HarvestDataSource(
     val dataSourceType: String? = null,
     val dataType: String? = null,
     val url: String? = null,
-    val acceptHeaderValue: String? = null
+    val acceptHeaderValue: String? = null,
+    val publisherId: String? = null
 )

--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/model/Organization.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/model/Organization.kt
@@ -1,0 +1,18 @@
+package no.fdk.fdk_concept_harvester.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Organization(
+    val organizationId: String? = null,
+    val uri: String? = null,
+    val name: String? = null,
+    val prefLabel: PrefLabel? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PrefLabel(
+    val nb: String? = null,
+    val nn: String? = null,
+    val en: String? = null
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
 application:
   conceptsUri: ${FDK_CONCEPT_HARVESTER_URI:https://concepts.staging.fellesdatakatalog.digdir.no}/concepts
   collectionsUri: ${FDK_CONCEPT_HARVESTER_URI:https://concepts.staging.fellesdatakatalog.digdir.no}/collections
+  organizationsUri: ${ORGANIZATION_CATALOGUE_URI:https://organization-catalogue.staging.fellesdatakatalog.digdir.no}/organizations
   harvestAdminRootUrl: ${HARVEST_ADMIN_ROOT_URL:http://fdk-harvest-admin:8080/api}
 
 ---
@@ -33,6 +34,7 @@ spring:
 application:
   conceptsUri: https://concepts.staging.fellesdatakatalog.digdir.no/concepts
   collectionsUri: https://concepts.staging.fellesdatakatalog.digdir.no/collections
+  organizationsUri: https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations
   harvestAdminRootUrl: https://admin-api.staging.fellesdatakatalog.digdir.no/api
 
 ---
@@ -50,4 +52,5 @@ spring:
 application:
   conceptsUri: http://localhost:5000/concepts
   collectionsUri: http://localhost:5000/collections
+  organizationsUri: http://localhost:5000/organizations
   harvestAdminRootUrl: http://localhost:5000/api

--- a/src/test/kotlin/no/fdk/fdk_concept_harvester/utils/TestData.kt
+++ b/src/test/kotlin/no/fdk/fdk_concept_harvester/utils/TestData.kt
@@ -1,6 +1,9 @@
 package no.fdk.fdk_concept_harvester.utils
 
+import no.fdk.fdk_concept_harvester.model.CollectionMeta
 import no.fdk.fdk_concept_harvester.model.HarvestDataSource
+import no.fdk.fdk_concept_harvester.model.Organization
+import no.fdk.fdk_concept_harvester.model.PrefLabel
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import java.util.*
 
@@ -23,17 +26,34 @@ val TEST_HARVEST_SOURCE_0 = HarvestDataSource(
     url = "http://localhost:5000/concept-harvest-source-0",
     acceptHeaderValue = "text/turtle",
     dataType = "concept",
-    dataSourceType = "SKOS-AP-NO"
+    dataSourceType = "SKOS-AP-NO",
+    publisherId = "123456789"
 )
 
 val TEST_HARVEST_SOURCE_1 = HarvestDataSource(
     url = "http://localhost:5000/concept-harvest-source-1",
     acceptHeaderValue = "text/turtle",
     dataType = "concept",
-    dataSourceType = "SKOS-AP-NO"
+    dataSourceType = "SKOS-AP-NO",
+    publisherId = "987654321"
 )
 
 const val COLLECTION_0_ID = "9b8f1c42-1161-33b1-9d43-a733ee94ddfc"
 
 const val CONCEPT_0_ID = "db1b701c-b4b9-3c20-bc23-236a91236754"
 const val CONCEPT_1_ID = "7dbac738-4944-323a-a777-ad2f83bf75f8"
+
+const val GENERATED_COLLECTION_ID = "24a90ee1-bd80-390b-8cfc-983960909392"
+
+val GENERATED_COLLECTION = CollectionMeta(
+    uri = "http://localhost:5000/concept-harvest-source-0#GeneratedCollection", fdkId = GENERATED_COLLECTION_ID,
+    issued = 1609852539831, modified = 1609852539831,
+    concepts = setOf("https://example.com/begrep/0")
+)
+
+val ORGANIZATION_0 = Organization(
+    organizationId = "123456789",
+    uri = "http://localhost:5000/organizations/123456789",
+    name = "TESTDIREKTORATET",
+    prefLabel = PrefLabel(nb = "Testdirektoratet")
+)

--- a/src/test/resources/no_meta_generated_collection.ttl
+++ b/src/test/resources/no_meta_generated_collection.ttl
@@ -1,0 +1,40 @@
+@prefix schema: <http://schema.org/> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix skosno: <http://difi.no/skosno#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+
+<http://localhost:5000/concept-harvest-source-0#GeneratedCollection>
+        a              skos:Collection ;
+        rdfs:label     "Testdirektoratet - Begrepssamling"@nb , "TESTDIREKTORATET - Begrepssamling"@nn , "TESTDIREKTORATET - Concept collection"@en ;
+        dct:publisher  <http://localhost:5000/organizations/123456789> ;
+        skos:member    <https://example.com/begrep/0> .
+
+<https://example.com/begrep/0>
+    a                   skos:Concept ;
+    dct:identifier      "ebd994c6-0688-4a11-b500-64d8131152dc" ;
+    dct:modified        "2020-04-03"^^xsd:date ;
+    dct:publisher       <https://data.brreg.no/enhetsregisteret/api/enheter/910244132> ;
+    dct:subject         "data"@nb ;
+    dct:temporal        [ a                 dct:PeriodOfTime ;
+                         schema:endDate    "2020-04-23"^^xsd:date ;
+                         schema:startDate  "2020-04-01"^^xsd:date ] ;
+    skos:example        "Felles Datakatalog og Data.norge.no slåes sammen"@nb ;
+    skosxl:altLabel     [ a                   skosxl:Label ;
+                         skosxl:literalForm  "FDK"@nb ] ;
+    skosxl:hiddenLabel  [ a                   skosxl:Label ;
+                         skosxl:literalForm  "Felles Norge "@nb ] ;
+    skosxl:prefLabel    [ a                   skosxl:Label ;
+                         skosxl:literalForm  "data.norge.no"@nb ] ;
+    dcat:contactPoint   [ a                   vcard:Organization ;
+                         vcard:hasEmail      <mailto:test@data.norge.no> ;
+                         vcard:hasTelephone  <tel:12312311> ] ;
+    skosno:definisjon   [ a                       skosno:Definisjon ;
+                         rdfs:label              "I forbindelse med sammenslåing av data.norge.no og FDK må dette begrepet defineres."@nb ;
+                         dct:source              [ rdfs:label    "Data Norge"@nb ;
+                                                   rdfs:seeAlso  <https://data.norge.no> ] ;
+                         skosno:forholdTilKilde  skosno:basertPåKilde ] .


### PR DESCRIPTION
resolves #71 

Hvordan den ene katalogen i prod det gjelder vil bli seende ut:
```
<https://raw.githubusercontent.com/akhvidsten/skosmapping/master/Virksomhetsarkitektur#GeneratedCollection>
        a              skos:Collection ;
        rdfs:label     "DIGITALISERINGSDIREKTORATET - Concept collection"@en , "DIGITALISERINGSDIREKTORATET - Begrepssamling"@nn , "DIGITALISERINGSDIREKTORATET - Begrepssamling"@nb ;
        dct:publisher  <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
        skos:member    <https://begrep.difi.no/49> , <https://begrep.difi.no/25> , <https://begrep.difi.no/51> , <https://begrep.difi.no/32> , <https://begrep.difi.no/17> , <https://begrep.difi.no/30> , <https://begrep.difi.no/20> , <https://begrep.difi.no/11> , <https://begrep.difi.no/60> , <https://begrep.difi.no/53> , <https://begrep.difi.no/45> , <https://begrep.difi.no/36> , <https://begrep.difi.no/47> , <https://begrep.difi.no/18> , <https://begrep.difi.no/21> , <https://begrep.difi.no/29> , <https://begrep.difi.no/57> , <https://begrep.difi.no/24> , <https://begrep.difi.no/9> , <https://begrep.difi.no/2> , <https://begrep.difi.no/44> , <https://begrep.difi.no/38> , <https://begrep.difi.no/31> .
```