### PR TITLE
chore: specify max memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 VOLUME /tmp
 COPY /target/fdk-concept-harvester.jar app.jar
 
-CMD java -jar $JAVA_OPTS app.jar
+CMD java -jar -Xmx3g $JAVA_OPTS app.jar


### PR DESCRIPTION
Ser den makser minnebruk, som datasetthøsteren også gjorde når vi starta høsting av den store katalogen til kartverket, setter samme minnebegrensing som vi da ga datasetthøsteren