### PR TITLE
Disable CSRF and parsing of DTD

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/configuration/SecurityConfig.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/configuration/SecurityConfig.kt
@@ -23,7 +23,6 @@ open class SecurityConfig(
     @Bean
     open fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http {
-            csrf { disable() }
             cors {
                 configurationSource = CorsConfigurationSource {
                     val config = CorsConfiguration()


### PR DESCRIPTION
Sånn eg har forstått det er det unødvendig å ha med denne linjen då Spring ikkje bryr seg med CSRF så lenge det er eit JWT bearer token i request. Og Get-endepunkt er vel ikkje berørt av CSRF. 

The safest way to prevent XXE is always to disable DTDs (External Entities) completely.
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
 