### PR TITLE
chore: scheduled harvest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>3.4.1</version>
+      <version>3.4.3</version>
       <relativePath/>
     </parent>
 
@@ -28,9 +28,9 @@
         <maven.exec.skip>false</maven.exec.skip>
         <!--end standard properties-->
 
-        <kotlin.version>2.1.0</kotlin.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
-        <jena.version>5.2.0</jena.version>
+        <kotlin.version>2.1.10</kotlin.version>
+        <testcontainers.version>1.20.5</testcontainers.version>
+        <jena.version>5.3.0</jena.version>
     </properties>
 
     <dependencies>
@@ -127,13 +127,13 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.10.0</version>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/Application.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/Application.kt
@@ -3,11 +3,13 @@ package no.fdk.fdk_concept_harvester
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableWebSecurity
+@EnableScheduling
 open class Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/no/fdk/fdk_concept_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/fdk/fdk_concept_harvester/harvester/HarvesterActivity.kt
@@ -15,6 +15,7 @@ import no.fdk.fdk_concept_harvester.service.UpdateService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.Calendar
 import kotlin.time.measureTimedValue
@@ -34,6 +35,10 @@ class HarvesterActivity(
 
     @EventListener
     fun fullHarvestOnStartup(event: ApplicationReadyEvent) = initiateHarvest(HarvestAdminParameters(null, null, null), false)
+
+    @Scheduled(cron = "0 30 * * * *")
+    fun scheduledHarvest() =
+        initiateHarvest(HarvestAdminParameters(null, null, null), false)
 
     fun initiateHarvest(params: HarvestAdminParameters, forceUpdate: Boolean) {
         if (params.harvestAllConcepts()) LOGGER.debug("starting harvest of all concept collections, force update: $forceUpdate")


### PR DESCRIPTION
Fra slack:

> prøvde å oppdatere fdk-harvest-scheduler på fredag, men den får nå en mystisk Killed melding på ca 50% av kjøringene sine i staging, også når jeg går tilbake til forrige versjon av image. Ble litt lei av å måtte fikse komplisert feil i en applikasjon jeg synes vi bare burde stenge ned, så tok meg den friheten å stenge den ned i staging og oppretta en pr på hver høster med hva som skal til for å kunne stenge den ned.
> 
> https://github.com/Informasjonsforvaltning/fdk-dataset-harvester/pull/258
> https://github.com/Informasjonsforvaltning/fdk-concept-harvester/pull/203
> https://github.com/Informasjonsforvaltning/fdk-dataservice-harvester/pull/205
> https://github.com/Informasjonsforvaltning/fdk-informationmodel-harvester/pull/180
> https://github.com/Informasjonsforvaltning/fdk-event-harvester/pull/136
> https://github.com/Informasjonsforvaltning/fdk-public-service-harvester/pull/152
> 
> Det vil resultere i at høsterene selv holder på schedule for de høstingene som kjøres automatisk, i stedet for at de lytter til rabbit-meldingene som fdk-harvest-scheduler sender. Er dette ok? Isf kan vi stenge ned og arkivere fdk-harvest-scheduler